### PR TITLE
fix wrong matrix order for 2x2 option in drawtiles (swap b and c)

### DIFF
--- a/src/com/asliceofcrazypie/flash/TilesheetStage3D.hx
+++ b/src/com/asliceofcrazypie/flash/TilesheetStage3D.hx
@@ -294,8 +294,8 @@ class TilesheetStage3D extends Tilesheet
 					if ( isMatrix )
 					{
 						transform_a = tileData[tileDataPos + 3];
-						transform_c = tileData[tileDataPos + 4];
-						transform_b = tileData[tileDataPos + 5];
+						transform_b = tileData[tileDataPos + 4];
+						transform_c = tileData[tileDataPos + 5];
 						transform_d = tileData[tileDataPos + 6];
 					}
 					else

--- a/src/com/asliceofcrazypie/nme/TilesheetStage3D.hx
+++ b/src/com/asliceofcrazypie/nme/TilesheetStage3D.hx
@@ -286,8 +286,8 @@ class TilesheetStage3D extends Tilesheet
 					if ( isMatrix )
 					{
 						transform_a = tileData[tileDataPos + 3];
-						transform_c = tileData[tileDataPos + 4];
-						transform_b = tileData[tileDataPos + 5];
+						transform_b = tileData[tileDataPos + 4];
+						transform_c = tileData[tileDataPos + 5];
 						transform_d = tileData[tileDataPos + 6];
 					}
 					else


### PR DESCRIPTION
This order matches the original drawTiles() from the base tilesheet
